### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
     "support_url": "https://github.com/larkox/mattermost-plugin-badges/issues",
     "release_notes_url": "https://github.com/larkox/mattermost-plugin-badges/releases/tag/v0.1.2",
     "icon_path": "assets/starter-template-icon.svg",
-    "version": "0.2.0",
+    "version": "0.1.3",
     "min_server_version": "5.12.0",
     "server": {
         "executables": {

--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
     "support_url": "https://github.com/larkox/mattermost-plugin-badges/issues",
     "release_notes_url": "https://github.com/larkox/mattermost-plugin-badges/releases/tag/v0.1.2",
     "icon_path": "assets/starter-template-icon.svg",
-    "version": "0.1.2",
+    "version": "0.2.0",
     "min_server_version": "5.12.0",
     "server": {
         "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -19,7 +19,7 @@ const manifestStr = `
   "support_url": "https://github.com/larkox/mattermost-plugin-badges/issues",
   "release_notes_url": "https://github.com/larkox/mattermost-plugin-badges/releases/tag/v0.1.2",
   "icon_path": "assets/starter-template-icon.svg",
-  "version": "0.2.0",
+  "version": "0.1.3",
   "min_server_version": "5.12.0",
   "server": {
     "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -19,7 +19,7 @@ const manifestStr = `
   "support_url": "https://github.com/larkox/mattermost-plugin-badges/issues",
   "release_notes_url": "https://github.com/larkox/mattermost-plugin-badges/releases/tag/v0.1.2",
   "icon_path": "assets/starter-template-icon.svg",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "min_server_version": "5.12.0",
   "server": {
     "executables": {


### PR DESCRIPTION
Fixes https://github.com/larkox/mattermost-plugin-badges/issues/11

Compare with previous release https://github.com/larkox/mattermost-plugin-badges/compare/v0.1.2...master

- https://github.com/larkox/mattermost-plugin-badges/pull/5
- https://github.com/larkox/mattermost-plugin-badges/commit/359791b6cb07b84306a26b669546a03e7fd1d953 - Fix console errors when fetching the custom emojis
- https://github.com/larkox/mattermost-plugin-badges/commit/80f777e172364cf02f094be2b3868553dc1b8735 - Not allow "notify in channel" if the user has no permission to post on the channel.
- https://github.com/larkox/mattermost-plugin-badges/pull/7