### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,9 +4,9 @@
     "description": "This plugin add badges support to Mattermost.",
     "homepage_url": "https://github.com/larkox/mattermost-plugin-badges",
     "support_url": "https://github.com/larkox/mattermost-plugin-badges/issues",
-    "release_notes_url": "https://github.com/larkox/mattermost-plugin-badges/releases/tag/v0.1.2",
+    "release_notes_url": "https://github.com/larkox/mattermost-plugin-badges/releases/tag/v0.2.0",
     "icon_path": "assets/starter-template-icon.svg",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "min_server_version": "5.12.0",
     "server": {
         "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -17,9 +17,9 @@ const manifestStr = `
   "description": "This plugin add badges support to Mattermost.",
   "homepage_url": "https://github.com/larkox/mattermost-plugin-badges",
   "support_url": "https://github.com/larkox/mattermost-plugin-badges/issues",
-  "release_notes_url": "https://github.com/larkox/mattermost-plugin-badges/releases/tag/v0.1.2",
+  "release_notes_url": "https://github.com/larkox/mattermost-plugin-badges/releases/tag/v0.2.0",
   "icon_path": "assets/starter-template-icon.svg",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "min_server_version": "5.12.0",
   "server": {
     "executables": {


### PR DESCRIPTION
This is identical to 0.1.3, but following what we've been doing with other plugins, adding the App Bar icon should be a minor version bump.