### PR TITLE
Fix "twitch" effect when more than 1 row of badges exist

### DIFF
--- a/webapp/src/components/user_popover/badge_list.scss
+++ b/webapp/src/components/user_popover/badge_list.scss
@@ -1,0 +1,24 @@
+#badgeList {
+  #contentContainer {
+    display: flex;
+    align-content: flex-end;
+    align-items: center;
+  }
+
+  #showMoreButton {
+    background-color: rgb(255, 255, 255);
+    color: rgba(63, 67, 80, 0.56);
+    border: 0;
+    border-radius: 4px;
+    font-weight: 600;
+    height: 24px;
+    width: 24px;
+    font-size: 18px;
+    margin-left: 6px;
+    padding: 0;
+
+    &:hover {
+      background-color: rgba(63, 67, 80, 0.08);
+    }
+  }
+}

--- a/webapp/src/components/user_popover/badge_list.scss
+++ b/webapp/src/components/user_popover/badge_list.scss
@@ -1,4 +1,4 @@
-#badgeList {
+#badgePlugin {
   #contentContainer {
     display: flex;
     align-content: flex-end;
@@ -18,7 +18,24 @@
     padding: 0;
 
     &:hover {
-      background-color: rgba(63, 67, 80, 0.08);
+      background: rgba(63, 67, 80, 0.08);
+      color: rgba(63, 67, 80, 0.72);
+    }
+  }
+
+  #grantBadgeButton {
+    margin-top: 4px;
+    padding-left: 0;
+    border: 0;
+    background-color: rgb(255, 255, 255);
+    color: rgb(28, 88, 217);
+    font-size: 12px;
+    font-weight: 600;
+    gap: 6px;
+    line-height: 10px;
+
+    .fa-plus-circle {
+      margin-right: 4px;
     }
   }
 }

--- a/webapp/src/components/user_popover/badge_list.tsx
+++ b/webapp/src/components/user_popover/badge_list.tsx
@@ -14,6 +14,8 @@ import {RHSState} from 'types/general';
 import {IMAGE_TYPE_EMOJI, RHS_STATE_DETAIL, RHS_STATE_MY, RHS_STATE_OTHER} from '../../constants';
 import {markdown} from 'utils/markdown';
 
+import './badge_list.scss';
+
 type Props = {
     debug: GlobalState;
     user: UserProfile;
@@ -35,8 +37,8 @@ type State = {
     loaded?: Boolean;
 }
 
-const MAX_BADGES = 20;
-const BADGES_PER_ROW = 10;
+const MAX_BADGES = 7;
+const BADGE_SIZE = 24;
 
 class BadgeList extends React.PureComponent<Props, State> {
     constructor(props: Props) {
@@ -109,7 +111,7 @@ class BadgeList extends React.PureComponent<Props, State> {
         let row: React.ReactNode[] = [];
         for (let i = 0; i < toShow; i++) {
             const badge = this.state.badges![i];
-            if (i !== 0 && i % BADGES_PER_ROW === 0) {
+            if (i !== 0) {
                 content.push((<div>{row}</div>));
                 row = [];
             }
@@ -133,7 +135,7 @@ class BadgeList extends React.PureComponent<Props, State> {
                         <a onClick={() => this.onBadgeClick(badge)}>
                             <BadgeImage
                                 badge={badge}
-                                size={24}
+                                size={BADGE_SIZE}
                             />
                         </a>
                     </span>
@@ -145,24 +147,36 @@ class BadgeList extends React.PureComponent<Props, State> {
         let andMore: React.ReactNode = null;
         if (nBadges > MAX_BADGES) {
             andMore = (
-                <a onClick={this.onMoreClick}>
-                    <div>{`and ${nBadges - MAX_BADGES} more`}</div>
-                </a>
+                <OverlayTrigger
+                    overlay={<Tooltip>{`and ${nBadges - MAX_BADGES} more. Click to see all.`}</Tooltip>}
+                >
+                    <button
+                        id='showMoreButton'
+                        onClick={this.onMoreClick}
+                    >
+                        <span className={'fa fa-angle-right'}/>
+                    </button>
+                </OverlayTrigger>
             );
         }
+        const maxWidth = (MAX_BADGES * BADGE_SIZE) + 30;
         let loading: React.ReactNode = null;
         if (!this.state.loaded) {
             loading = (
 
-                // Reserve enough height for two rows of badges and the "and more" link
-                <div style={{height: 64}}>{'Loading...'}</div>
+                // Reserve enough height one row of badges and the "and more" button
+                <div style={{height: BADGE_SIZE, minWidth: 66, maxWidth}}>
+                    {'Loading...'}
+                </div>
             );
         }
         return (
-            <div>
+            <div id='badgeList'>
                 <div><b>{'Badges'}</b></div>
-                {content}
-                {andMore}
+                <div id='contentContainer' >
+                    {content}
+                    {andMore}
+                </div>
                 {loading}
                 <a onClick={this.onGrantClick}>
                     <div>{'Grant badge'}</div>

--- a/webapp/src/components/user_popover/badge_list.tsx
+++ b/webapp/src/components/user_popover/badge_list.tsx
@@ -34,7 +34,7 @@ type Props = {
 
 type State = {
     badges?: UserBadge[];
-    loaded?: Boolean;
+    loaded?: boolean;
 }
 
 const MAX_BADGES = 7;
@@ -171,16 +171,21 @@ class BadgeList extends React.PureComponent<Props, State> {
             );
         }
         return (
-            <div id='badgeList'>
+            <div id='badgePlugin'>
                 <div><b>{'Badges'}</b></div>
                 <div id='contentContainer' >
                     {content}
                     {andMore}
                 </div>
                 {loading}
-                <a onClick={this.onGrantClick}>
-                    <div>{'Grant badge'}</div>
-                </a>
+                <button
+                    id='grantBadgeButton'
+                    onClick={this.onGrantClick}
+                >
+                    <span className={'fa fa-plus-circle'}/>
+                    {'Grant badge'}
+                </button>
+                <hr className='divider divider--expanded'/>
             </div>
         );
     }

--- a/webapp/src/components/user_popover/badge_list.tsx
+++ b/webapp/src/components/user_popover/badge_list.tsx
@@ -108,14 +108,8 @@ class BadgeList extends React.PureComponent<Props, State> {
         const toShow = nBadges < MAX_BADGES ? nBadges : MAX_BADGES;
 
         const content: React.ReactNode[] = [];
-        let row: React.ReactNode[] = [];
         for (let i = 0; i < toShow; i++) {
             const badge = this.state.badges![i];
-            if (i !== 0) {
-                content.push((<div>{row}</div>));
-                row = [];
-            }
-
             const time = new Date(badge.time);
             let reason = null;
             if (badge.reason) {
@@ -123,7 +117,7 @@ class BadgeList extends React.PureComponent<Props, State> {
             }
             const badgeComponent = (
                 <OverlayTrigger
-                    overlay={<Tooltip>
+                    overlay={<Tooltip id='badgeTooltip'>
                         <div>{badge.name}</div>
                         <div>{markdown(badge.description)}</div>
                         {reason}
@@ -141,14 +135,15 @@ class BadgeList extends React.PureComponent<Props, State> {
                     </span>
                 </OverlayTrigger>
             );
-            row.push(badgeComponent);
+            content.push(badgeComponent);
         }
-        content.push((<div>{row}</div>));
         let andMore: React.ReactNode = null;
         if (nBadges > MAX_BADGES) {
             andMore = (
                 <OverlayTrigger
-                    overlay={<Tooltip>{`and ${nBadges - MAX_BADGES} more. Click to see all.`}</Tooltip>}
+                    overlay={<Tooltip id='badgeMoreTooltip'>
+                        {`and ${nBadges - MAX_BADGES} more. Click to see all.`}
+                    </Tooltip>}
                 >
                     <button
                         id='showMoreButton'


### PR DESCRIPTION
This PR introduces UI changes to prevent "twitch" effect when user has more than 1 row of badges. 

Fixes: https://github.com/larkox/mattermost-plugin-badges/issues/6
Fixes https://github.com/mattermost/mattermost-server/issues/22138
Fixes https://mattermost.atlassian.net/browse/MM-49809


**before** 

https://user-images.githubusercontent.com/37421564/215112135-2b08a892-925d-4d0f-a0d3-9d0541bc605b.mov

**after** 

https://user-images.githubusercontent.com/37421564/215111516-1daab8b5-30c3-4b61-878d-2a2ce39d1574.mov